### PR TITLE
Handle ACF oEmbed formatting separately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2021-12-09
+
+### Changed
+- Handle ACF oEmbed formatting separately.
 
 ## [1.0.2] - 2021-12-08
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "wordpress-plugin-cookiebot",
-    "version": "1.0.2",
+    "version": "1.1.0",
     "description": "Helper plugin for handling Cookiebot consent states",
     "private": true,
     "dependencies": {

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: Cookiebot Helper
  * Plugin URI: https://github.com/devgeniem/wp-cookiebot-helper
  * Description: Helper plugin for handling Cookiebot consent states
- * Version: 1.0.2
+ * Version: 1.1.0
  * Requires PHP: 7.0
  * Author: Geniem Oy / Hermanni Piirainen
  * Author URI: https://geniem.com

--- a/src/Handlers/YouTube.php
+++ b/src/Handlers/YouTube.php
@@ -38,7 +38,7 @@ class YouTube {
      * Class constructor
      */
     public function __construct() {
-        $this->opt_out_type   = ConsentType::MARKETING;
+        $this->opt_out_type = ConsentType::MARKETING;
         $this->hooks();
     }
 
@@ -49,7 +49,24 @@ class YouTube {
      */
     protected function hooks() {
         \add_filter( 'embed_oembed_html', [ $this, 'add_placeholder' ], 10, 2 );
-        \add_filter( 'acf/format_value/type=oembed', [ $this, 'add_placeholder' ], 20, 2 );
+        \add_filter( 'acf/format_value/type=oembed', [ $this, 'format_acf_oembed' ], 20, 3 );
+    }
+
+    /**
+     * Get the original video URL and add placeholder.
+     *
+     * @param mixed      $value The field value.
+     * @param int|string $post_id The post ID.
+     * @param array      $field The field array containing all settings.
+     * @return string
+     */
+    public function format_acf_oembed( $value, $post_id, $field ) {
+        if ( function_exists( 'get_field' ) ) {
+            $url = \get_field( $field['name'], $post_id, false );
+            return $this->add_placeholder( $value, $url );
+        }
+
+        return $value;
     }
 
     /**


### PR DESCRIPTION
`acf/format_value/type=oembed` parametrit eroaa niistä, mitä `embed_oembed_html` tarjoaa, joten ACF:n oEmbed-kenttiä varten tarvitaan lisälogiikkaa. Tässä haetaan videon alkuperäinen URL kannasta, koska ACF:n filtterin parameterit sisältää YouTuben embed-URLin eikä alkuperäistä.