### PR TITLE
Removed ! is_admin() logic from Youtube class init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [youtube-hooks-default-wp] - 2023-02-28
+- Youtube class init by default WP no extra `is_admin()` restriction.
+
 ## [1.1.5] - 2023-02-06
 
 ### Added

--- a/src/CookiebotPlugin.php
+++ b/src/CookiebotPlugin.php
@@ -112,22 +112,20 @@ final class CookiebotPlugin {
      * @return void
      */
     protected function init_handlers() {
-        if ( ! \is_admin() ) {
 
-            /*
-                Uncomment the line below when parsing the consent cookie server-side is needed.
-                See README > Notes about caching for more information.
-            */
-            // $this->cookie_handler = new CookieHandler();
+        /*
+            Uncomment the line below when parsing the consent cookie server-side is needed.
+            See README > Notes about caching for more information.
+        */
+        // $this->cookie_handler = new CookieHandler();
 
-            $this->handlers = [
-                Handlers\YouTube::class,
-            ];
+        $this->handlers = [
+            Handlers\YouTube::class,
+        ];
 
-            foreach ( $this->handlers as $handler_class ) {
-                if ( class_exists( $handler_class ) ) {
-                    new $handler_class();
-                }
+        foreach ( $this->handlers as $handler_class ) {
+            if ( class_exists( $handler_class ) ) {
+                new $handler_class();
             }
         }
     }


### PR DESCRIPTION
This ! is_admin() logic adds layer for default WP running logic. Youtube class runs code in WP hooks. Causes problems with indexing type of functionalities.